### PR TITLE
An example decrypting a machine file instead of a license file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "chalk": "^2.3.2"
+    "chalk": "^2.3.2",
+    "node-machine-id": "^1.1.12"
   }
 }


### PR DESCRIPTION
Used in conjunction with this script to checkout a machine file:

```js
const { machineId } = require('node-machine-id');

const KEYGEN_ACCOUNT_ID = 'my-account-id';

 async function checkoutMachineFile(license_key) {
	const fingerprint = await machineId();

	const url = `https://api.keygen.sh/v1/accounts/${KEYGEN_ACCOUNT_ID}/machines/${fingerprint}/actions/check-out?encrypt=1`;

	const response = await fetch(url, {
		method: 'POST',
		headers: {
			Accept: 'application/vnd.api+json',
			Authorization: `License ${license_key}`,
		},
	});

	const { data, errors } = await response.json();

	if (errors) {
		console.error(errors);
		return false;
	}

	return data.attributes.certificate;
};

```